### PR TITLE
fix(validate): retry a 429 in the link check instead of accepting it

### DIFF
--- a/tools/validate_skills.py
+++ b/tools/validate_skills.py
@@ -77,6 +77,7 @@ import argparse
 import json
 import re
 import sys
+import time
 
 # Said here rather than left to `import tomllib`, which on 3.10 fails as
 # ModuleNotFoundError -- a message that reads like a missing dependency in a tool whose
@@ -287,6 +288,14 @@ URL_RE = re.compile(r"https?://[^\s<>\"'`\]\\]+")
 INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 LINK_TIMEOUT = 15
 LINK_WORKERS = 8
+# A 429 is retried rather than accepted as 'unknown'. Rate limiting only warns, which
+# is the right call for someone else's outage — but a host that rate-limits us instead
+# of answering hides whatever the real answer was, and a gate that reports 'reachable'
+# because it was throttled is worse than one that reports nothing. Documentation hosts
+# do this readily: eight workers over ~100 URLs concentrated on a handful of hosts is
+# enough to trigger it.
+LINK_RETRIES = 3
+LINK_RETRY_CAP = 8.0
 # Some documentation hosts answer a bare urllib request with 403. This is the
 # minimum that makes them behave; it is not an attempt to look like a browser.
 LINK_HEADERS = {
@@ -576,33 +585,64 @@ def link_targets(body: str, source: dict | None) -> list[tuple[str, str, bool]]:
     return targets
 
 
+def retry_after(exc: urllib.error.HTTPError, attempt: int) -> float:
+    """How long to wait before retrying a throttled request.
+
+    Retry-After comes in two forms and only the seconds form is honoured. The HTTP
+    date form is what a host sends when the wait is minutes, which is longer than a
+    CI step should hold a pull request open for — exponential backoff and then a
+    warning is the better answer there.
+    """
+    header = exc.headers.get("Retry-After") if exc.headers else None
+    try:
+        wait = float(header)
+    except (TypeError, ValueError):
+        wait = 2.0**attempt
+    return min(max(wait, 0.0), LINK_RETRY_CAP)
+
+
 def probe_url(url: str) -> tuple[str, str]:
     """Reachability of one URL: ('ok'|'dead'|'unknown', detail).
 
     'dead' is reserved for an answer from the server that the target does not
-    exist. Everything else — rate limiting, a 5xx, DNS trouble, a timeout — is
-    'unknown', because a validator that fails a pull request when someone else's
-    CDN hiccups teaches contributors to ignore it.
+    exist. Everything else — a 5xx, DNS trouble, a timeout — is 'unknown', because a
+    validator that fails a pull request when someone else's CDN hiccups teaches
+    contributors to ignore it.
 
     HEAD first, GET on rejection: some hosts answer HEAD with 403 or 405 while
     serving the page. The GET is not read, only opened.
+
+    A 429 is retried with backoff before it is allowed to become 'unknown'. It is the
+    one 'unknown' a host returns *instead of* the real answer rather than alongside
+    it, so accepting it on the first try makes the verdict depend on how busy someone
+    else's CDN was — the same commit passing and failing minutes apart, with a dead
+    link the throttled run never got far enough to see.
     """
-    for method in ("HEAD", "GET"):
-        request = urllib.request.Request(url, method=method, headers=LINK_HEADERS)
-        try:
-            with urllib.request.urlopen(request, timeout=LINK_TIMEOUT) as response:
-                return "ok", f"{response.status}"
-        except urllib.error.HTTPError as exc:
-            if exc.code in (404, 410):
-                return "dead", f"HTTP {exc.code}"
-            if method == "HEAD" and exc.code in (403, 405, 400, 501):
-                continue
-            return "unknown", f"HTTP {exc.code}"
-        except urllib.error.URLError as exc:
-            return "unknown", f"{type(exc.reason).__name__}: {exc.reason}"
-        except (TimeoutError, OSError) as exc:
-            return "unknown", f"{type(exc).__name__}: {exc}"
-    return "unknown", "no method accepted"
+    for attempt in range(LINK_RETRIES + 1):
+        throttled = None
+        for method in ("HEAD", "GET"):
+            request = urllib.request.Request(url, method=method, headers=LINK_HEADERS)
+            try:
+                with urllib.request.urlopen(request, timeout=LINK_TIMEOUT) as response:
+                    return "ok", f"{response.status}"
+            except urllib.error.HTTPError as exc:
+                if exc.code in (404, 410):
+                    return "dead", f"HTTP {exc.code}"
+                if exc.code == 429:
+                    throttled = exc
+                    break
+                if method == "HEAD" and exc.code in (403, 405, 400, 501):
+                    continue
+                return "unknown", f"HTTP {exc.code}"
+            except urllib.error.URLError as exc:
+                return "unknown", f"{type(exc.reason).__name__}: {exc.reason}"
+            except (TimeoutError, OSError) as exc:
+                return "unknown", f"{type(exc).__name__}: {exc}"
+        if throttled is None:
+            return "unknown", "no method accepted"
+        if attempt < LINK_RETRIES:
+            time.sleep(retry_after(throttled, attempt))
+    return "unknown", f"HTTP 429 after {LINK_RETRIES + 1} attempts"
 
 
 def check_links(


### PR DESCRIPTION
**3 of 5** in a split stack.

| # | PR | scope | base |
|---|---|---|---|
| 1 | #9 | a dead link in an imported body warns instead of failing — **unblocks Validate** | `main` |
| 2 | #12 | scope the Pages token to the deploy job and pin its actions — **unblocks Security** | `main` |
| 3 | #10 | retry a 429 in the link check instead of accepting it | #9 |
| 4 | #11 | run the pinned-upstream check even when the link check failed | #9 |
| 5 | #13 | group the codeql-action pins so both halves move together | #9 |

#9 and #12 are independent and both go straight to `main` — they fix the two unrelated jobs
that are red there, and neither waits on the other. #10, #11 and #13 sit on #9 only so their
Validate runs are green while `main`'s link check is failing; GitHub retargets them to `main`
when #9 lands.

`main` is failing two independent jobs, so any PR fixing one still *displays* the other.
Nothing here introduces the failure it shows:

| PR | red check | fixed by |
|---|---|---|
| #9, #10, #11, #13 | `zizmor` — the Pages workflow from #7 | #12 |
| #12 | `validate` — the dead docs.vllm.ai link | #9 |

Everything else is green on every PR. All five test-merge into `main` cleanly in any order,
and the merged combination passes the full gate plus zizmor and actionlint.

## What this changes

The link check reported two different verdicts for the same tree three seconds apart this
morning, on two dependabot pull requests over identical skills:

```
04:48:39  WARN ... xpu-installation.html was not reachable (HTTP 429)   → pass
04:48:42  FAIL ... xpu-installation.html is gone (HTTP 404)             → fail
```

The first run's probe was throttled by docs.vllm.ai. Rate limiting maps to `unknown`, which
warns, so it went green — reporting a dead link as reachable.

Mapping rate limiting to a warning is right; the alternative is failing a contributor's pull
request because someone else's CDN was busy. What is wrong is **accepting it on the first
try**. Every other `unknown` is an answer given *alongside* the real one — a timeout or a
5xx tells you nothing about whether the page exists, and there is nothing better to do than
say so. A 429 is an answer given *instead of* the real one, and here it stood in for a 404.

So a 429 is now retried before it is allowed to become a warning: `Retry-After` when the
host sends it in seconds, exponential otherwise, capped at 8s per wait and 3 retries. Worst
case adds ~7s for one thoroughly throttled URL, in parallel across workers.

The HTTP-date form of `Retry-After` is deliberately **not** honoured. A host saying "come
back in four minutes" is asking for longer than a CI step should hold a pull request open,
and the warning is the better answer there.

Why this host and why now: 8 workers over 99 URLs, a dozen of them on two documentation
domains, is enough to trip a per-IP limit on a shared runner. Nothing about the repository
changed for it to start happening, and nothing has to change for it to happen again.

## Verified

A live 429 cannot be summoned on demand, so this was checked against a stubbed opener:

| stub | result |
|---|---|
| 429 every time | `('unknown', 'HTTP 429 after 4 attempts')`, 4 attempts made |
| **429 then 404** | **`('dead', 'HTTP 404')`** ← the case that went green this morning |
| HEAD 403 then GET 200 | `('ok', '200')` — existing fallback unchanged |
| no `Retry-After` | waits 1, 2, 4, 8, 8, 8 (capped) |
| `Retry-After` as an HTTP date | falls back to exponential |

## Checklist

- [x] I checked `description` against requests a user would really type — see CONTRIBUTING.md. *(no skill text changed)*
- [x] `python3 tools/validate_skills.py` passes locally.
- [x] Every commit is signed off with `git commit -s` (DCO).
