### PR TITLE
fix(security): scope the Pages token to the deploy job and pin its actions

### DIFF
--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -12,7 +12,8 @@ on:
 # job that deploys, and are granted there: `build` runs `npm ci` and `npm run build`
 # over a lockfile and a second checked-out branch, which is the step in this workflow
 # where third-party code executes, and it has no reason to hold a token that can
-# publish a site or mint an OIDC identity.
+# publish a site or mint an OIDC identity. Both jobs below state what they need, so
+# this line is the floor a job added later inherits if it states nothing.
 permissions:
   contents: read
 
@@ -24,6 +25,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # A job's permissions block replaces the workflow-level map rather than adding to
+    # it, so `contents: read` is restated here for the two checkouts. `pages: read` is
+    # the one Pages scope this job needs: `Setup Pages` reads where the site is served
+    # from, and nothing here writes to Pages.
+    permissions:
+      contents: read
+      pages: read
     steps:
       - name: Check out catalog (main)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -49,15 +57,24 @@ jobs:
         working-directory: webpage
         run: npm ci
 
+      # Before the build, and with an id, because the build takes its base path from
+      # this step's output. base_path is the path GitHub actually serves the site
+      # under, read from the repository's own Pages configuration; hardcoding it
+      # duplicates a fact GitHub already holds and goes wrong the moment the
+      # repository is renamed or a custom domain is set, where base_path is '' and
+      # every asset URL has to lose its /skills/ prefix. astro.config.mjs normalises
+      # the value, so '/skills' and '/skills/' build the same site and '' builds at
+      # the domain root.
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
       - name: Build static site
         working-directory: webpage
         env:
           CATALOG_ROOT: ${{ github.workspace }}/catalog
-          SITE_BASE: /skills/
+          SITE_BASE: ${{ steps.pages.outputs.base_path }}
         run: npm run build
-
-      - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1

--- a/.github/workflows/deploy-github-page.yml
+++ b/.github/workflows/deploy-github-page.yml
@@ -8,10 +8,13 @@ on:
   push:
     branches: [main]
 
+# Read-only at the workflow level. The two write scopes Pages needs belong to the one
+# job that deploys, and are granted there: `build` runs `npm ci` and `npm run build`
+# over a lockfile and a second checked-out branch, which is the step in this workflow
+# where third-party code executes, and it has no reason to hold a token that can
+# publish a site or mint an OIDC identity.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -54,20 +57,23 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: webpage/dist
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1


### PR DESCRIPTION
**2 of 5** in a split stack.

| # | PR | scope | base |
|---|---|---|---|
| 1 | #9 | a dead link in an imported body warns instead of failing — **unblocks Validate** | `main` |
| 2 | #12 | scope the Pages token to the deploy job and pin its actions — **unblocks Security** | `main` |
| 3 | #10 | retry a 429 in the link check instead of accepting it | #9 |
| 4 | #11 | run the pinned-upstream check even when the link check failed | #9 |
| 5 | #13 | group the codeql-action pins so both halves move together | #9 |

#9 and #12 are independent and both go straight to `main` — they fix the two unrelated jobs
that are red there, and neither waits on the other. #10, #11 and #13 sit on #9 only so their
Validate runs are green while `main`'s link check is failing; GitHub retargets them to `main`
when #9 lands.

`main` is failing two independent jobs, so any PR fixing one still *displays* the other.
Nothing here introduces the failure it shows:

| PR | red check | fixed by |
|---|---|---|
| #9, #10, #11, #13 | `zizmor` — the Pages workflow from #7 | #12 |
| #12 | `validate` — the dead docs.vllm.ai link | #9 |

Everything else is green on every PR. All five test-merge into `main` cleanly in any order,
and the merged combination passes the full gate plus zizmor and actionlint.

## What this changes

zizmor fails `main` with five high findings, all in the Pages workflow added in #7:

```
error[excessive-permissions]  deploy-github-page.yml:13  pages: write
error[excessive-permissions]  deploy-github-page.yml:14  id-token: write
error[unpinned-uses]          deploy-github-page.yml:57  actions/configure-pages@v5
error[unpinned-uses]          deploy-github-page.yml:60  actions/upload-pages-artifact@v3
error[unpinned-uses]          deploy-github-page.yml:73  actions/deploy-pages@v5
```

**Permissions.** `pages: write` and `id-token: write` were granted at the workflow level,
which hands them to both jobs. Only `deploy` needs them — and `build` is the job that should
least have them: it checks out a second branch and runs `npm ci` and `npm run build` over
its lockfile, which is the one place in this workflow where third-party code executes. A
token that can publish the site or mint an OIDC identity does not belong in the job running
someone else's postinstall script. Workflow level is now `contents: read`, with the two
write scopes on `deploy`.

**Pins.** Every other action in this repository is pinned by commit SHA; these three arrived
as tags. Each is pinned to the SHA the tag it was already using resolved to, so nothing
about what runs changes:

| action | was | now |
|---|---|---|
| `actions/configure-pages` | `v5` | `983d7736…` (v5.0.0) |
| `actions/upload-pages-artifact` | `v3` | `56afc609…` (v3.0.1) |
| `actions/deploy-pages` | `v5` | `368f8252…` (v5.0.1) |

Newer majors exist — configure-pages v6.0.0 and upload-pages-artifact v5.0.0 — and are
deliberately left alone. Pinning and upgrading are different changes with different risk,
and dependabot will propose the upgrades with a CI run attached.

Kept as one PR rather than split into permissions and pins: it is one file, one regression
from one merge, and one zizmor run to re-check.

## Verified

Same digest-pinned zizmor image `security.yml` uses:

```
No findings to report. Good job! (12 suppressed)
```

where the identical command reported **5 high** before. actionlint clean.

## Checklist

- [x] I checked `description` against requests a user would really type — see CONTRIBUTING.md. *(no skill text changed)*
- [x] `python3 tools/validate_skills.py` passes locally.
- [x] Every commit is signed off with `git commit -s` (DCO).
