### PR TITLE
chore(deps): group the codeql-action pins so both halves move together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,15 @@ updates:
     # "Loaded a configuration file for version '4.37.9', but running version '4.36.2'".
     # Ungrouped, dependabot opens one pull request per path, so each one bumps half the
     # pair and cannot pass its own CI. Grouping makes the pin move as the unit it is.
+    # The pattern is stated twice because a group covers version updates only unless it
+    # says otherwise: a security advisory on one half would arrive as its own
+    # single-dependency pull request and split the pin exactly as above.
     groups:
       codeql-action:
+        applies-to: version-updates
+        patterns:
+          - "github/codeql-action*"
+      codeql-action-security:
+        applies-to: security-updates
         patterns:
           - "github/codeql-action*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    # codeql-action/init and codeql-action/analyze are two entry points into one
+    # action, and the bundle checks at runtime that both halves are the same release:
+    # "Loaded a configuration file for version '4.37.9', but running version '4.36.2'".
+    # Ungrouped, dependabot opens one pull request per path, so each one bumps half the
+    # pair and cannot pass its own CI. Grouping makes the pin move as the unit it is.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
**5 of 5** in a split stack.

| # | PR | scope | base |
|---|---|---|---|
| 1 | #9 | a dead link in an imported body warns instead of failing — **unblocks Validate** | `main` |
| 2 | #12 | scope the Pages token to the deploy job and pin its actions — **unblocks Security** | `main` |
| 3 | #10 | retry a 429 in the link check instead of accepting it | #9 |
| 4 | #11 | run the pinned-upstream check even when the link check failed | #9 |
| 5 | #13 | group the codeql-action pins so both halves move together | #9 |

#9 and #12 are independent and both go straight to `main` — they fix the two unrelated jobs
that are red there, and neither waits on the other. #10, #11 and #13 sit on #9 only so their
Validate runs are green while `main`'s link check is failing; GitHub retargets them to `main`
when #9 lands.

`main` is failing two independent jobs, so any PR fixing one still *displays* the other.
Nothing here introduces the failure it shows:

| PR | red check | fixed by |
|---|---|---|
| #9, #10, #11, #13 | `zizmor` — the Pages workflow from #7 | #12 |
| #12 | `validate` — the dead docs.vllm.ai link | #9 |

Everything else is green on every PR. All five test-merge into `main` cleanly in any order,
and the merged combination passes the full gate plus zizmor and actionlint.

## What this changes

Dependabot opened two pull requests this morning and neither can pass:

```
#5 (codeql-action/init)     Loaded a configuration file for version '4.37.9',
                            but running version '4.36.2'
#6 (codeql-action/analyze)  Loaded a configuration file for version '4.36.2',
                            but running version '4.37.9'
```

`github/codeql-action/init` and `github/codeql-action/analyze` are two entry points into one
action, and the bundle checks at runtime that both halves came from the same release.
Ungrouped, dependabot treats each path as its own dependency and opens a pull request per
path — so each one bumps half the pair and leaves the workflow internally inconsistent. The
failure is not a regression in either version, and not something either pull request can fix
on its own.

Grouping makes the pin move as the unit it already is. It is also the only dependency here
where that applies: everything else in `.github/workflows` is a standalone action whose
version is nobody else's business.

## Needs a maintainer action

**#5 and #6 have to be closed** for the grouped pull request to replace them — dependabot
will not fold existing single-dependency pull requests into a new group. I have not touched
them.

## Checklist

- [x] I checked `description` against requests a user would really type — see CONTRIBUTING.md. *(no skill text changed)*
- [x] `python3 tools/validate_skills.py` passes locally.
- [x] Every commit is signed off with `git commit -s` (DCO).
